### PR TITLE
Propagate return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,15 @@ use target_test_dir::test_with_dir;
 use std::path::PathBuf;
 
 #[test_with_dir]
-fn write_and_read_hello_world(testdir: PathBuf) {
+fn write_and_read_hello_world(testdir: PathBuf) -> std::io::Result<()> {
     let hwpath = testdir.join("hello_world.txt");
-    std::fs::write(&hwpath, "Hello World!").unwrap();
+    std::fs::write(&hwpath, "Hello World!")?;
 
-    let bytes = std::fs::read(hwpath).unwrap();
+    let bytes = std::fs::read(hwpath)?;
     let output = String::from_utf8(bytes).unwrap();
 
     assert_eq!(&output, "Hello World!");
+    Ok(())
 }
 ```
 

--- a/support/src/procmacro.rs
+++ b/support/src/procmacro.rs
@@ -3,7 +3,11 @@ use proc_macro2::TokenStream;
 /// Transform a token stream of a test function definition into a proper `#[test]` fn
 ///
 /// This requires the input to be a fn item just like a standard `#[test]` function _except_ it
-/// takes a single [std::path::PathBuf] argument to an empty test-specific directory.
+/// takes a single [std::path::PathBuf] argument to an empty test-specific directory. Any return
+/// type is propagated, although any errors during setting up the test directory cause panics.
+///
+/// Almost every use of this function would be via the `test_with_dir` macro within the
+/// `target-test-dir` crate; see that crate for examples.
 pub fn transform_test_with_dir<TS>(input: TS) -> TS
 where
     TokenStream: From<TS>,

--- a/support/src/procmacro.rs
+++ b/support/src/procmacro.rs
@@ -50,3 +50,6 @@ fn transform_test_with_dir_inner(input: TokenStream) -> Result<TokenStream, syn:
         #implfn
     })
 }
+
+#[cfg(test)]
+mod tests;

--- a/support/src/procmacro.rs
+++ b/support/src/procmacro.rs
@@ -29,10 +29,13 @@ fn transform_test_with_dir_inner(input: TokenStream) -> Result<TokenStream, syn:
     let implname = Ident::new(&format!("{}_impl", &testnamestr), testname.span());
     implfn.sig.ident = implname.clone();
 
+    // Propagate the return type:
+    let output = implfn.sig.output.clone();
+
     // TODO: propagate the user test return type.
     Ok(quote! {
         #[test]
-        fn #testname() {
+        fn #testname() #output {
             let testdir =
             ::target_test_dir_support::get_base_test_dir()
                 .join(format!("{}-{}", module_path!().replace("::", "-"), #testnamestr));

--- a/support/src/procmacro/tests.rs
+++ b/support/src/procmacro/tests.rs
@@ -35,3 +35,40 @@ fn unit_return() {
 
     assert_eq!(output.to_string(), expected.to_string());
 }
+
+#[test]
+fn result_return() {
+    let input = quote! {
+        fn my_test(testdir: PathBuf) -> std::io::Result<()> {
+            assert!(testdir.is_dir());
+            Ok(())
+        }
+    };
+
+    let output = transform_test_with_dir(input);
+
+    let expected = quote! {
+        #[test]
+        fn my_test() -> std::io::Result<()> {
+            let testdir =
+            ::target_test_dir_support::get_base_test_dir()
+                .join(format!("{}-{}", module_path!().replace("::", "-"), "my_test"));
+
+            match std::fs::create_dir(&testdir) {
+                Ok(()) => {}
+                Err(e) => {
+                    panic!("Could not create test dir {:?}: {}", testdir.display(), e);
+                }
+            }
+
+            my_test_impl(testdir)
+        }
+
+        fn my_test_impl(testdir: PathBuf) -> std::io::Result<()> {
+            assert!(testdir.is_dir());
+            Ok(())
+        }
+    };
+
+    assert_eq!(output.to_string(), expected.to_string());
+}

--- a/support/src/procmacro/tests.rs
+++ b/support/src/procmacro/tests.rs
@@ -1,0 +1,37 @@
+use crate::transform_test_with_dir;
+use quote::quote;
+
+#[test]
+fn unit_return() {
+    let input = quote! {
+        fn my_test(testdir: PathBuf) {
+            assert!(testdir.is_dir());
+        }
+    };
+
+    let output = transform_test_with_dir(input);
+
+    let expected = quote! {
+        #[test]
+        fn my_test() {
+            let testdir =
+            ::target_test_dir_support::get_base_test_dir()
+                .join(format!("{}-{}", module_path!().replace("::", "-"), "my_test"));
+
+            match std::fs::create_dir(&testdir) {
+                Ok(()) => {}
+                Err(e) => {
+                    panic!("Could not create test dir {:?}: {}", testdir.display(), e);
+                }
+            }
+
+            my_test_impl(testdir)
+        }
+
+        fn my_test_impl(testdir: PathBuf) {
+            assert!(testdir.is_dir());
+        }
+    };
+
+    assert_eq!(output.to_string(), expected.to_string());
+}

--- a/target-test-dir/src/lib.rs
+++ b/target-test-dir/src/lib.rs
@@ -6,6 +6,9 @@ use target_test_dir_support::transform_test_with_dir;
 /// Annotate a test function which takes a single [std::path::PathBuf] argument which will be a
 /// freshly created directory
 ///
+/// The annotated function must behave like a standard `#[test]` fn with the addition of a single
+/// [std::path::PathBuf] argument. Any return type is propagated.
+///
 /// See the [crate] docs for an example.
 #[proc_macro_attribute]
 pub fn test_with_dir(_args: TokenStream, input: TokenStream) -> TokenStream {


### PR DESCRIPTION
Add support for tests with non-`()` return types, such as `std::io::Result`.