### PR TITLE
Args passthrough

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,33 +4,43 @@ version = 3
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ceca8aaf45b5c46ec7ed39fff75f57290368c1846d33d24a122ca81416ab058"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "fcf316d5356ed6847742d036f8a39c3b8435cac10bd528a4bd461928a6ab34d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -49,6 +59,7 @@ dependencies = [
 name = "target-test-dir-macro"
 version = "0.2.0"
 dependencies = [
+ "prettyplease",
  "proc-macro2",
  "quote",
  "syn",
@@ -56,6 +67,6 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,11 @@ repository = "https://github.com/nathan-at-least/target-test-dir"
 [workspace.dependencies]
 once_cell = "1.15.0"
 proc-macro2 = "1.0.47"
-quote = "1.0.21"
+quote = "*"
+prettyplease = "0.2.4"
 
 [workspace.dependencies.syn]
-version = "1.0.103"
+version = "2.0.14"
 features = [
   "full",
 ]

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -15,3 +15,6 @@ proc-macro = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
+
+[dev-dependencies]
+prettyplease.workspace = true

--- a/macro/src/procmacro.rs
+++ b/macro/src/procmacro.rs
@@ -33,13 +33,52 @@ fn transform_test_with_dir_inner(input: TokenStream) -> Result<TokenStream, syn:
     let implname = Ident::new(&format!("{}_impl", &testnamestr), testname.span());
     implfn.sig.ident = implname.clone();
 
+    // We want to propagate all args except the last, which is the testdir:
+    let mut wrapper_inputs = implfn.sig.inputs.clone();
+    wrapper_inputs.pop(); // Remove the last arg from propagation.
+
+    // Now we want to propagate the arg bindings in the call, with comma termination:
+    let arg_call_names = {
+        use syn::{
+            punctuated::Punctuated, spanned::Spanned, token::Comma, Error, Expr, FnArg::Typed, Pat,
+            PatIdent, PatType,
+        };
+
+        let mut pct = Punctuated::<Expr, Comma>::new();
+        for fnarg in &wrapper_inputs {
+            if let Typed(PatType { pat, .. }) = fnarg {
+                if let Pat::Ident(PatIdent { ident, .. }) = &**pat {
+                    pct.push(syn::parse2(quote! { #ident })?);
+                } else {
+                    return Err(Error::new(
+                        fnarg.span(),
+                        "unexpected pattern; expecting identifier",
+                    ));
+                }
+            } else {
+                return Err(Error::new(
+                    fnarg.span(),
+                    "unexpected received; expecting `<identifier>: <type>`",
+                ));
+            }
+        }
+
+        if !pct.is_empty() {
+            pct.push_punct(Comma::default());
+        }
+
+        pct
+    };
+
     // Propagate the return type:
     let output = implfn.sig.output.clone();
 
     Ok(quote! {
         #[test]
-        fn #testname() #output {
+        fn #testname( #wrapper_inputs ) #output {
             #implname (
+                #arg_call_names
+
                 // We initialize and pass the testdir in a local scope to avoid collutions in
                 // #testnate scope:
                 {

--- a/macro/src/procmacro/tests.rs
+++ b/macro/src/procmacro/tests.rs
@@ -1,8 +1,9 @@
 use super::transform_test_with_dir;
+use proc_macro2::TokenStream;
 use quote::quote;
 
 #[test]
-fn unit_return() {
+fn no_args_unit_return() {
     let input = quote! {
         fn my_test(testdir: PathBuf) {
             assert!(testdir.is_dir());
@@ -34,11 +35,11 @@ fn unit_return() {
         }
     };
 
-    assert_eq!(output.to_string(), expected.to_string());
+    assert_tokens_eq(expected, output);
 }
 
 #[test]
-fn result_return() {
+fn no_args_result_return() {
     let input = quote! {
         fn my_test(testdir: PathBuf) -> std::io::Result<()> {
             assert!(testdir.is_dir());
@@ -72,5 +73,60 @@ fn result_return() {
         }
     };
 
-    assert_eq!(output.to_string(), expected.to_string());
+    assert_tokens_eq(expected, output);
+}
+
+#[test]
+fn extra_args_unit_return() {
+    let input = quote! {
+        fn my_test(s: &str, i: i64, testdir: PathBuf) -> std::io::Result<()> {
+            assert!(testdir.is_dir());
+            assert_eq!(i, i64::from_str(s).unwrap());
+            Ok(())
+        }
+    };
+
+    let output = transform_test_with_dir(input);
+
+    let expected = quote! {
+        #[test]
+        fn my_test(s: &str, i: i64) -> std::io::Result<()> {
+            my_test_impl(
+                s,
+                i,
+                {
+                    let testdir =
+                    ::target_test_dir::get_base_test_dir()
+                        .join(format!("{}-{}", module_path!().replace("::", "-"), "my_test"));
+
+                    if let Some(e) = std::fs::create_dir(&testdir).err() {
+                        panic!("Could not create test dir {:?}: {}", testdir.display(), e);
+                    };
+
+                    testdir
+                }
+            )
+        }
+
+        fn my_test_impl(s: &str, i: i64, testdir: PathBuf) -> std::io::Result<()> {
+            assert!(testdir.is_dir());
+            assert_eq!(i, i64::from_str(s).unwrap());
+            Ok(())
+        }
+    };
+
+    assert_tokens_eq(expected, output);
+}
+
+fn assert_tokens_eq(expected: TokenStream, actual: TokenStream) {
+    let expected = prettify(expected);
+    let actual = prettify(actual);
+    assert_eq!(
+        &expected, &actual,
+        "Not equal:\n\n=== expected ===\n{expected}\n\n=== actual ===\n{actual}\n\n",
+    );
+}
+
+fn prettify(ts: TokenStream) -> String {
+    prettyplease::unparse(&syn::parse2::<syn::File>(ts).unwrap())
 }

--- a/macro/src/procmacro/tests.rs
+++ b/macro/src/procmacro/tests.rs
@@ -14,18 +14,19 @@ fn unit_return() {
     let expected = quote! {
         #[test]
         fn my_test() {
-            let testdir =
-            ::target_test_dir::get_base_test_dir()
-                .join(format!("{}-{}", module_path!().replace("::", "-"), "my_test"));
+            my_test_impl(
+                {
+                    let testdir =
+                    ::target_test_dir::get_base_test_dir()
+                        .join(format!("{}-{}", module_path!().replace("::", "-"), "my_test"));
 
-            match std::fs::create_dir(&testdir) {
-                Ok(()) => {}
-                Err(e) => {
-                    panic!("Could not create test dir {:?}: {}", testdir.display(), e);
+                    if let Some(e) = std::fs::create_dir(&testdir).err() {
+                        panic!("Could not create test dir {:?}: {}", testdir.display(), e);
+                    };
+
+                    testdir
                 }
-            }
-
-            my_test_impl(testdir)
+            )
         }
 
         fn my_test_impl(testdir: PathBuf) {
@@ -50,18 +51,19 @@ fn result_return() {
     let expected = quote! {
         #[test]
         fn my_test() -> std::io::Result<()> {
-            let testdir =
-            ::target_test_dir::get_base_test_dir()
-                .join(format!("{}-{}", module_path!().replace("::", "-"), "my_test"));
+            my_test_impl(
+                {
+                    let testdir =
+                    ::target_test_dir::get_base_test_dir()
+                        .join(format!("{}-{}", module_path!().replace("::", "-"), "my_test"));
 
-            match std::fs::create_dir(&testdir) {
-                Ok(()) => {}
-                Err(e) => {
-                    panic!("Could not create test dir {:?}: {}", testdir.display(), e);
+                    if let Some(e) = std::fs::create_dir(&testdir).err() {
+                        panic!("Could not create test dir {:?}: {}", testdir.display(), e);
+                    };
+
+                    testdir
                 }
-            }
-
-            my_test_impl(testdir)
+            )
         }
 
         fn my_test_impl(testdir: PathBuf) -> std::io::Result<()> {

--- a/macro/src/procmacro/tests.rs
+++ b/macro/src/procmacro/tests.rs
@@ -128,5 +128,14 @@ fn assert_tokens_eq(expected: TokenStream, actual: TokenStream) {
 }
 
 fn prettify(ts: TokenStream) -> String {
-    prettyplease::unparse(&syn::parse2::<syn::File>(ts).unwrap())
+    let tsstr = ts.to_string();
+    match syn::parse2::<syn::File>(ts) {
+        Ok(f) => prettyplease::unparse(&f),
+        Err(e) => panic!(
+            "internal parse error:\ntokens: {:#?}\nsource: {:?}\ndetail: {}",
+            tsstr,
+            e.span().source_text(),
+            e
+        ),
+    }
 }


### PR DESCRIPTION
This extends the macro to pass extra argument declarations through. The final argument must take the generated `PathBuf`.