### PR TITLE
Release 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license-file = "LICENSE"
 repository = "https://github.com/nathan-at-least/target-test-dir"

--- a/target-test-dir/Cargo.toml
+++ b/target-test-dir/Cargo.toml
@@ -16,4 +16,4 @@ once_cell.workspace = true
 
 [dependencies.target-test-dir-macro]
 path = "../macro"
-version = "^0.2.0"
+version = "^0.3.0"


### PR DESCRIPTION
This changes the API significantly to [look like this](https://github.com/nathan-at-least/target-test-dir/blob/aeb60570891919b65e69b82d094c7308659b7f44/target-test-dir/tests/basic.rs):

```
use target_test_dir::with_test_dir;

#[test]
#[with_test_dir]
fn ensure_test_dir_is_dir() {
    let testdir = get_test_dir!();
    dbg!(&testdir);
    assert!(testdir.is_dir());
}
```